### PR TITLE
Change protocol from git:// to https:// when cloning from GitHub

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,8 +35,8 @@ if [ "${INSTALL_ONLY}" != "TRUE" ]
 
     hg clone https://re2.googlecode.com/hg re2
 
-    git clone git://github.com/pfi/pficommon.git
-    git clone git://github.com/jubatus/jubatus.git
+    git clone https://github.com/pfi/pficommon.git
+    git clone https://github.com/jubatus/jubatus.git
 
   cd ..
 fi


### PR DESCRIPTION
Under the network environment that require proxies (e.g., enterprise network), HTTPS is much preferable to Git protocol, as we can just use https_proxy environment variable instead of setting up custom Git proxy command.
