### PR TITLE
Eliminate most LD_LIBRARY_PATH from install.sh.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -193,8 +193,6 @@ if [ "${DOWNLOAD_ONLY}" != "TRUE" ]
     export PATH=${PREFIX}/bin:$PATH
     export PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
     export LDFLAGS="-L${PREFIX}/lib"
-    export LD_LIBRARY_PATH="${PREFIX}/lib"
-    export DYLD_LIBRARY_PATH="${PREFIX}/lib"
     export C_INCLUDE_PATH="${PREFIX}/include"
     export CPLUS_INCLUDE_PATH="${PREFIX}/include"
 
@@ -223,7 +221,7 @@ if [ "${DOWNLOAD_ONLY}" != "TRUE" ]
     check_result $?
 
     cd ../ux-${UX_VER}
-    ./waf configure --prefix=${PREFIX} && ./waf build && ./waf install
+    LINKFLAGS="-Wl,--rpath,${PREFIX}/lib" ./waf configure --prefix=${PREFIX} && ./waf build && ./waf install
     check_result $?
 
     cd ../mecab-${MECAB_VER}
@@ -270,9 +268,13 @@ if [ "${DOWNLOAD_ONLY}" != "TRUE" ]
     check_result $?
 
     cd ../jubatus-${JUBATUS_VER}
-    ./waf configure --prefix=${PREFIX} --enable-ux --enable-mecab --enable-zookeeper
+    LINKFLAGS="-Wl,-rpath,${PREFIX}/lib" ./waf configure --prefix=${PREFIX} --enable-ux --enable-mecab --enable-zookeeper
     check_result $?
-    ./waf build --checkall && ./waf install
+    ./waf build
+    check_result $?
+    LD_LIBRARY_PATH=${PREFIX}/lib DYLD_LIBRARY_PATH=${PREFIX}/lib ./waf --checkall
+    check_result $?
+    ./waf install
     check_result $?
 
     cat > ${PREFIX}/share/jubatus/jubatus.profile <<EOF
@@ -289,12 +291,6 @@ export CPLUS_INCLUDE_PATH
 
 LDFLAGS=-L\$JUBATUS_HOME/lib
 export LDFLAGS
-
-LD_LIBRARY_PATH=\$JUBATUS_HOME/lib
-export LD_LIBRARY_PATH
-
-DYLD_LIBRARY_PATH=\$JUBATUS_HOME/lib
-export DYLD_LIBRARY_PATH=\$JUBATUS_HOME/lib
 
 PKG_CONFIG_PATH=\$JUBATUS_HOME/lib/pkgconfig
 export PKG_CONFIG_PATH


### PR DESCRIPTION
Use rpath to find libraries instead of LD_LIBRARY_PATH.
Why LD_RUN_PATH is not used is that ld.gold does not recognize LD_RUN_PATH for now.
https://sourceware.org/bugzilla/show_bug.cgi?id=13764

https://github.com/jubatus/jubatus/issues/943
