### PR TITLE
add note for build requirements (python 2.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Requirements
 * g++
 * make
 * tar
-* python
+* python 2.x
 * python-dev (for `install_python.sh`)
 
-Note that some libraries cannot be built with Python 3.x.
-You may need to install Python 2.x if you don't have one.
-For example, if you are on Ubuntu 16.04, run `sudo apt-get install python2.7`.
+Due to the limitation of some libraries, jubatus-installer may fail when used with Python 3.x.
+Please make sure that your `python` command points to Python 2.x.
+If you are on Ubuntu 16.04 and you don't have `python` command, run `sudo apt-get install python2.7`.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Requirements
 * python
 * python-dev (for `install_python.sh`)
 
+Note that some libraries cannot be built with Python 3.x.
+You may need to install Python 2.x if you don't have one.
+For example, if you are on Ubuntu 16.04, run `sudo apt-get install python2.7`.
 
 Usage
 -----


### PR DESCRIPTION
As `waf` and `unittest_gtest.py` used in `ux-trie` are too old, it cannot be built without Python 2.

As Ubuntu 16.04 is shipped without Python 2, I added explicit notes regarding this issue to README.