### PR TITLE
explicitly specify libdir when configuring jubatus_core and jubatus

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -369,7 +369,7 @@ if [ "${DOWNLOAD_ONLY}" != "TRUE" ]
     check_result $?
 
     pushd jubatus_core-${JUBATUS_CORE_VER}
-    CONFIGURE_OPT="--prefix=${PREFIX}"
+    CONFIGURE_OPT="--prefix=${PREFIX} --libdir=${PREFIX}/lib"
     if [ "${USE_RE2}" == "TRUE" ]; then
       CONFIGURE_OPT="${CONFIGURE_OPT} --regexp-library=re2"
     fi
@@ -385,7 +385,7 @@ if [ "${DOWNLOAD_ONLY}" != "TRUE" ]
     popd
 
     pushd jubatus-${JUBATUS_VER}
-    CONFIGURE_OPT="--prefix=${PREFIX} --enable-ux --enable-mecab --enable-zookeeper"
+    CONFIGURE_OPT="--prefix=${PREFIX} --libdir=${PREFIX}/lib --enable-ux --enable-mecab --enable-zookeeper"
     if [ "${ENABLE_DEBUG}" == "TRUE" ]; then
       CONFIGURE_OPT="${CONFIGURE_OPT} --enable-debug"
     fi


### PR DESCRIPTION
This PR fixes the issue that install.sh does not work on 64-bit RHEL-based systems.

waf was upgraded in Jubatus / Core 1.0.2 release (https://github.com/jubatus/jubatus/pull/1181).
In recent versions of waf, it automatically _guesses_ the suffix of library directory name.
On 64-bit systems which has `/usr/lib64` directory (e.g., RHEL, CentOS, etc.), the suffix `64` is used.

https://github.com/waf-project/waf/blob/waf-1.9.7/waflib/Utils.py#L812-L824

So Jubatus Core is installed to `$PREFIX/lib64`, instead of `$PRFEIX/lib`.
As the installer script expects that all libraries to be installed under `$PREFIX/lib`, this change caused Jubatus build to fail with the following error (failed to find Jubatus Core installation):

```
Checking for 'jubatus_core'
['/root/local/bin/pkg-config', '--cflags', '--libs', 'jubatus_core']
err: Package jubatus_core was not found in the pkg-config search path.
Perhaps you should add the directory containing `jubatus_core.pc' to the PKG_CONFIG_PATH environment variable
No package 'jubatus_core' found
```